### PR TITLE
Modified sandwich.xacro to adjust left&right camera FOV

### DIFF
--- a/sandwich_description/urdf/sandwich.xacro
+++ b/sandwich_description/urdf/sandwich.xacro
@@ -60,9 +60,9 @@
   <xacro:property name="pinger_namespace" value="$(arg pinger_namespace)" scope="global" />
   
   <xacro:wamv_camera name="front_left_camera"  x="3.8" y="0.25"  z="1.3" 
-  post_z_from="1.1" P="${radians(15)}" />
+  post_z_from="1.1" P="${radians(0)}" Y="${radians(10)}" />
   <xacro:wamv_camera name="front_right_camera" x="3.8" y="-0.25" z="1.3" 
-  post_z_from="1.1" P="${radians(15)}" />
+  post_z_from="1.1" P="${radians(0)}" Y="${radians(-10)}"/>
   <xacro:lidar name="front_lidar" type="16_beam" x="3.9" z="1.4" 
   P="${radians(8)}" post_z_from="1.1"/>
   <xacro:wamv_gps name="gps" x="-1.0" z="1.28" 

--- a/sandwich_description/urdf/sandwich_thruster_config.xacro
+++ b/sandwich_description/urdf/sandwich_thruster_config.xacro
@@ -13,8 +13,8 @@
 			<!-- Optional Parameters -->
 			<mappingType>0</mappingType>
 			<maxCmd>1.0</maxCmd>
-			<maxForceFwd>12000.0</maxForceFwd>
-			<maxForceRev>-5000.0</maxForceRev>
+			<maxForceFwd>50000.0</maxForceFwd>
+			<maxForceRev>-50000.0</maxForceRev>
 			<maxAngle>${pi/2}</maxAngle>
 		</thruster>
 	</xacro:macro>

--- a/sandwich_description/urdf/thrusters.xacro
+++ b/sandwich_description/urdf/thrusters.xacro
@@ -33,7 +33,7 @@
     <!-- Dummy joint, which usv_gazebo_thrust_plugin looks for -->
     <joint name="left_chasis_engine_joint" type="revolute">
       <axis xyz="1 0 0"/>
-      <origin rpy="0 0 0" xyz="-3.8 0.7 0.285"/>
+      <origin rpy="0 0 0" xyz="-3.8 1.2 0.285"/>
       <parent link="${namespace}/base_link"/>
       <child link="left_engine_link"/>
       <limit lower="${-pi}" upper="${pi}" effort="10" velocity="10"/>
@@ -79,7 +79,7 @@
     <!-- Dummy joint, which usv_gazebo_thrust_plugin looks for -->
     <joint name="right_chasis_engine_joint" type="revolute">
       <axis xyz="1 0 0"/>
-      <origin rpy="0 0 0" xyz="-3.8 -0.7 0.285"/>
+      <origin rpy="0 0 0" xyz="-3.8 -1.2 0.285"/>
       <parent link="${namespace}/base_link"/>
       <child link="right_engine_link"/>
       <limit lower="${-pi}" upper="${pi}" effort="10" velocity="10"/>


### PR DESCRIPTION
# Summary

Modified sandwich.xacro to adjust left and right camera angles. 

# Test

After building workspace per [optical_swarm wiki](https://github.com/Field-Robotics-Lab/optical_swarm/wiki/workspace_setup)
```
cd sandwich_ws/src/sandwichboat
git checkout branch add_sandwich_model
cd ~/sandwich_ws
catkin_make_isolated
source devel_isolated/setup.bash
cd ~/sandwich_ws/src/sandwichboat/sandwicboat_gazebo
roslaunch sandwichboat_gazebo sydney_sandwich.launch
```
In a new terminal window:
```
source ~/sandwich_ws/devel_isolated/setup.bash
rosrun rqt_image_view rqt_image_view
```
Select the left and right /image_raw topics for each boat and verify that the field of view is level (no pitch offset) and angled outward (yaw offset of 10 degrees)